### PR TITLE
make chronid variable dynamic

### DIFF
--- a/function/da/chronologybyid.sql
+++ b/function/da/chronologybyid.sql
@@ -37,7 +37,7 @@ AS $function$
   LEFT JOIN ndb.chroncontroltypes AS ccrt ON ccr.chroncontroltypeid = ccrt.chroncontroltypeid
   LEFT JOIN ndb.datasets AS ds ON  ds.collectionunitid = chr.collectionunitid
   LEFT JOIN ndb.datasettypes AS dst ON dst.datasettypeid = ds.datasettypeid
-  WHERE chr.chronologyid = 123
+  WHERE chr.chronologyid = _chronid
   GROUP BY chr.isdefault,
         chr.chronologyname,
         aty.agetype,


### PR DESCRIPTION
This PR attempts to fix the chronology issue that was discovered in Explorer on November 21, 2020. The issue is that the database function has a hardcoded value for chronology id, however, this value should be dynamically passed in via the api.

@SimonGoring I plan to push this up via the python script after merging. 